### PR TITLE
Update matplotlib minimum pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ requires-python = ">=3.11"
 readme = "README.md"
 dynamic = ["version"]
 dependencies = [
-  "matplotlib>=2.0.0",
+  "matplotlib>=3.10.0",
   "numpy>=2.0.0",
   "pandas>=2.0.0",
 ]


### PR DESCRIPTION
Pin needs to be bumped due to use of 3D features that appear to have been released in mpl 3.10.0 (https://github.com/matplotlib/matplotlib/commit/29d886eab5d5ea54b023bb2601a0f83055ae4104).

Should fix `ImportError: cannot import name '_viewlim_mask' from 'mpl_toolkits.mplot3d.art3d'`.